### PR TITLE
Refactored naming db->instance

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -134,5 +134,5 @@ export const initializeOne = async (dbLoader: cfg.DbConfig): Promise<rxdb.RxData
 };
 
 export const initializeAll = async (loaders: cfg.DbConfig[]): Promise<Array<types.LoadedDb>> => {
-  return Promise.all(loaders.map((loader) => initializeOne(loader).then((db) => ({ ...loader, db }))));
+  return Promise.all(loaders.map((loader) => initializeOne(loader).then((db) => ({ ...loader, instance: db }))));
 };

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -87,4 +87,4 @@ export type Page = DbDocumentPrototype & { id: string; document_type: "page"; ti
 
 export type DbDocument = Page | Block | Execution | Data;
 
-export type LoadedDb = DbConfig & { db: rxdb.RxDatabase };
+export type LoadedDb = DbConfig & { instance: rxdb.RxDatabase };

--- a/src/frontend/containers/DBRenderer/DBRenderer.tsx
+++ b/src/frontend/containers/DBRenderer/DBRenderer.tsx
@@ -5,12 +5,12 @@ import * as queries from "../../../db/queries";
 import { RxQueryResultDoc, useRxQuery } from "rxdb-hooks";
 
 const DBRenderer = (dbL: dbTypes.LoadedDb) => {
-  const { db, name, description } = dbL;
+  const { instance, name, description } = dbL;
 
-  const { result: allBlocks }: RxQueryResultDoc<dbTypes.Block> = useRxQuery(queries.allBlocks(db));
-  const { result: allData }: RxQueryResultDoc<dbTypes.Data> = useRxQuery(queries.allData(db));
-  const { result: allExecutions }: RxQueryResultDoc<dbTypes.Execution> = useRxQuery(queries.allExecutions(db));
-  const { result: allPages }: RxQueryResultDoc<dbTypes.Page> = useRxQuery(queries.allPages(db));
+  const { result: allBlocks }: RxQueryResultDoc<dbTypes.Block> = useRxQuery(queries.allBlocks(instance));
+  const { result: allData }: RxQueryResultDoc<dbTypes.Data> = useRxQuery(queries.allData(instance));
+  const { result: allExecutions }: RxQueryResultDoc<dbTypes.Execution> = useRxQuery(queries.allExecutions(instance));
+  const { result: allPages }: RxQueryResultDoc<dbTypes.Page> = useRxQuery(queries.allPages(instance));
 
   return (
     <div>

--- a/src/frontend/containers/block/note.tsx
+++ b/src/frontend/containers/block/note.tsx
@@ -22,7 +22,7 @@ export const Component = (props: { db: dbTypes.LoadedDb; block: dbTypes.BlockNot
       state: block.state,
       type: "note",
     };
-    upsertOne(db.db, newBlock);
+    upsertOne(db.instance, newBlock);
   };
 
   return (
@@ -46,5 +46,5 @@ export const add = async (db: dbTypes.LoadedDb) => {
     document_type: "block",
     type: "note",
   };
-  await upsertOne(db.db, newNote);
+  await upsertOne(db.instance, newNote);
 };

--- a/src/frontend/containers/page/page.tsx
+++ b/src/frontend/containers/page/page.tsx
@@ -7,7 +7,7 @@ import PageBlocks from "../pageBlocks";
 const Page = (props: { db: dbTypes.LoadedDb; pageID: string }) => {
   const { pageID, db } = props;
 
-  const { result: doc } = useRxQuery(queries.page(db.db, pageID));
+  const { result: doc } = useRxQuery(queries.page(db.instance, pageID));
   const page: dbTypes.Page = doc[0]?.get();
 
   if (!page) {

--- a/src/frontend/containers/pageBlocks/pageBlocks.tsx
+++ b/src/frontend/containers/pageBlocks/pageBlocks.tsx
@@ -6,7 +6,7 @@ import { useRxQuery } from "rxdb-hooks";
 
 const PageBlocks = (props: { db: dbTypes.LoadedDb; page: dbTypes.Page }) => {
   const { page, db } = props;
-  const { result: docs } = useRxQuery(queries.pageBlocks(db.db, page));
+  const { result: docs } = useRxQuery(queries.pageBlocks(db.instance, page));
   const blocks: dbTypes.Block[] = docs.map((d) => d.get());
 
   return (

--- a/src/frontend/containers/pages/pages.tsx
+++ b/src/frontend/containers/pages/pages.tsx
@@ -4,20 +4,20 @@ import * as dbTypes from "../../../db/types";
 import * as queries from "../../../db/queries";
 import PageListItem from "../../components/pageListItem";
 
-const Pages = (props: { dbL: dbTypes.LoadedDb; open: (p: dbTypes.Page) => void }) => {
-  const { dbL, open } = props;
+const Pages = (props: { db: dbTypes.LoadedDb; open: (p: dbTypes.Page) => void }) => {
+  const { db, open } = props;
 
-  const { result: allDocs } = useRxQuery(queries.allPages(dbL.db));
+  const { result: allDocs } = useRxQuery(queries.allPages(db.instance));
   // something like this will have to be run after every query:
   // this gets out the data, that can be passed to react.  you can also call remove, etc
   // on these RxDocumentConstructors, so it might be helpful to keep them that way for longer
   const allPages: dbTypes.Page[] = allDocs.map((d) => d.get());
-  const pages = (ps) => ps.map((p) => <PageListItem page={p} open={() => open(p)} />);
+  const pages = (ps: dbTypes.Page[]) => ps.map((p) => <PageListItem page={p} open={() => open(p)} />);
 
   return (
     <div>
-      <h3>{dbL.name}</h3>
-      <p>{dbL.description}</p>
+      <h3>{db.name}</h3>
+      <p>{db.description}</p>
       {pages(allPages)}
     </div>
   );

--- a/src/frontend/pages/app.tsx
+++ b/src/frontend/pages/app.tsx
@@ -22,10 +22,10 @@ const ApplicationContainer = () => {
     <div>
       <div style={{ width: "30%", backgroundColor: "beige", float: "left" }}>
         {dbs.map((d) => (
-          <Pages dbL={d} open={openPage(d)} />
+          <Pages db={d} open={openPage(d)} />
         ))}
       </div>
-      <div>{activePage && <Page db={activeDb} pageID={activePage} />}</div>
+      <div>{activePage && activeDb && <Page db={activeDb} pageID={activePage} />}</div>
     </div>
   );
 };

--- a/src/frontend/pages/components/BlockTest.tsx
+++ b/src/frontend/pages/components/BlockTest.tsx
@@ -14,7 +14,7 @@ const docs: dbTypes.DbDocument[] = generateTestingDocs1();
 
 const AllBlocks = (props: {db: LoadedDb}) => {
   const { db } = props;
-  const { result: docs } = useRxQuery(queries.allBlocks(db.db));
+  const { result: docs } = useRxQuery(queries.allBlocks(db.instance));
   const blocks: dbTypes.Block[] = docs.map((d) => d.get());
 
   return (
@@ -32,9 +32,9 @@ const BlockDev = () => {
     // load the database if it's already not in the state,
     // protects against hot reloading
     instance || db.initializeOne(loader)
-                  .then(d => ({ ...loader, db: d }))
+                  .then(d => ({ ...loader, instance: d }))
                   .then(d => {
-                    db.upsertDocs(d.db, docs);
+                    db.upsertDocs(d.instance, docs);
                     setDb(d);
                   });
   }, []);
@@ -43,7 +43,7 @@ const BlockDev = () => {
     <>
       <div style={{width: "49%", float: "left"}}>
       {instance && <AllBlocks db={instance} />}
-        <AddBlock db={instance} />
+        {instance && <AddBlock db={instance} />}
 
       </div>
 

--- a/src/frontend/pages/components/devPanel.tsx
+++ b/src/frontend/pages/components/devPanel.tsx
@@ -16,9 +16,9 @@ const DevPanel = () => {
 
   if (!firstDb) return <>No Db</>;
 
-  const clearDbs = () => dbs.map((d) => db.clearDocs(d.db));
+  const clearDbs = () => dbs.map((d) => db.clearDocs(d.instance));
 
-  const addTestingDataDbs = () => dbs.map((d) => addTestingData(d.db));
+  const addTestingDataDbs = () => dbs.map((d) => addTestingData(d.instance));
 
   return (
     <>


### PR DESCRIPTION
To help with legibility and nesting, the rxdb in type LoadedDb is now
called instance, instead of db.  this avoids `db.db` in the code.

some other small related changes.