### PR TITLE
Feat/46 use paths in tsconfig (closes #46)

### DIFF
--- a/src/frontend/components/pageListItem/pageListItem.tsx
+++ b/src/frontend/components/pageListItem/pageListItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import * as dbTypes from "../../../db/types";
+import * as dbTypes from "@db/types";
 
 const PageListItem = (props: { page: dbTypes.Page; open: () => void }) => {
   const { page, open } = props;

--- a/src/frontend/containers/DBRenderer/DBRenderer.tsx
+++ b/src/frontend/containers/DBRenderer/DBRenderer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import RenderData from "../../components/renderData";
-import * as dbTypes from "../../../db/types";
-import * as queries from "../../../db/queries";
+import RenderData from "@frontend/components/renderData";
+import * as dbTypes from "@db/types";
+import * as queries from "@db/queries";
 import { RxQueryResultDoc, useRxQuery } from "rxdb-hooks";
 
 const DBRenderer = (dbL: dbTypes.LoadedDb) => {

--- a/src/frontend/containers/block/addBlock.tsx
+++ b/src/frontend/containers/block/addBlock.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { RxDatabase } from "rxdb";
-import * as dbTypes from "../../../db/types";
-import { promiseAsHook } from "../../utils";
+import * as dbTypes from "@db/types";
+import { promiseAsHook } from "@frontend/utils";
 
 import * as note from "./note";
 

--- a/src/frontend/containers/block/index.tsx
+++ b/src/frontend/containers/block/index.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { RxDatabase } from "rxdb";
-import * as dbTypes from "../../../db/types";
-
+import * as dbTypes from "@db/types";
 import * as note from "./note";
 
 const NotFoundType = ({block}: {block: dbTypes.Block}) =>

--- a/src/frontend/containers/block/note.tsx
+++ b/src/frontend/containers/block/note.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-
 import { v4 as uuidv4 } from "uuid";
-
-import { upsertOne } from "../../../db";
-import * as dbTypes from "../../../db/types";
+import { upsertOne } from "@db/index";
+import * as dbTypes from "@db/types";
 
 export const Component = (props: { db: dbTypes.LoadedDb; block: dbTypes.BlockNote }) => {
   const { db, block } = props;

--- a/src/frontend/containers/configEditor/configEditor.tsx
+++ b/src/frontend/containers/configEditor/configEditor.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import * as cfgTypes from "../../../cfg/types";
+import * as cfgTypes from "@cfg/types";
 import { omit, get } from "lodash/fp";
-import * as Logger from "../../../logger";
-import * as cfg from "../../../cfg";
+import * as Logger from "@logger/index";
+import * as cfg from "@cfg/index";
 import JSONEditor from "react-json-editor-ajrm";
 
 const log = Logger.makeLogger("frontent/pages/config");

--- a/src/frontend/containers/page/page.tsx
+++ b/src/frontend/containers/page/page.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import * as dbTypes from "../../../db/types";
-import * as queries from "../../../db/queries";
+import * as dbTypes from "@db/types";
+import * as queries from "@db/queries";
 import { useRxQuery } from "rxdb-hooks";
-import PageBlocks from "../pageBlocks";
+import PageBlocks from "@frontend/containers/pageBlocks";
 
 const Page = (props: { db: dbTypes.LoadedDb; pageID: string }) => {
   const { pageID, db } = props;

--- a/src/frontend/containers/pageBlocks/pageBlocks.tsx
+++ b/src/frontend/containers/pageBlocks/pageBlocks.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import * as dbTypes from "../../../db/types";
-import * as queries from "../../../db/queries";
-import Block from "../../containers/block";
+import * as dbTypes from "@db/types";
+import * as queries from "@db/queries";
+import Block from "@frontend/containers/block";
 import { useRxQuery } from "rxdb-hooks";
 
 const PageBlocks = (props: { db: dbTypes.LoadedDb; page: dbTypes.Page }) => {

--- a/src/frontend/containers/pages/pages.tsx
+++ b/src/frontend/containers/pages/pages.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { useRxQuery } from "rxdb-hooks";
-import * as dbTypes from "../../../db/types";
-import * as queries from "../../../db/queries";
-import PageListItem from "../../components/pageListItem";
+import * as dbTypes from "@db/types";
+import * as queries from "@db/queries";
+import PageListItem from "@frontend/components/pageListItem";
 
 const Pages = (props: { dbL: dbTypes.LoadedDb; open: (p: dbTypes.Page) => void }) => {
   const { dbL, open } = props;

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -4,7 +4,7 @@ import * as dbTypes from "@db/types";
 import { AppProps } from "next/app";
 import * as cfg from "@cfg/index";
 
-import "../styles/globals.css";
+import "@frontend/styles/globals.css";
 
 import { DbsContext } from "./_context";
 

--- a/src/frontend/pages/_app.tsx
+++ b/src/frontend/pages/_app.tsx
@@ -1,18 +1,16 @@
 import React, { useState, useEffect } from "react";
-import * as db from "../../db";
-import * as dbTypes from "../../db/types";
+import * as db from "@db/index"
+import * as dbTypes from "@db/types";
 import { AppProps } from "next/app";
-import * as cfg from "../../cfg";
+import * as cfg from "@cfg/index";
 
 import "../styles/globals.css";
 
 import { DbsContext } from "./_context";
 
-import { useStore, setLocalStorage } from "../../store";
-
 import DevPanel from "./components/devPanel";
 
-import * as Logger from "../../logger";
+import * as Logger from "@logger/index";
 
 const log = Logger.makeLogger("frontent/pages/_app");
 
@@ -25,11 +23,7 @@ const App = ({ Component, pageProps }: AppProps) => {
     log.debug(`loaded config`, c);
     setConfig(c);
   };
-  const { data } = useStore();
 
-  useEffect(() => {
-    setLocalStorage("state", data);
-  }, [data]);
 
   const loadDbs = async () => {
     if (!config) {

--- a/src/frontend/pages/app.tsx
+++ b/src/frontend/pages/app.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import * as dbTypes from "../../db/types";
+import * as dbTypes from "@db/types";
 import { DbsContext } from "./_context";
-import Page from "../containers/page";
-import Pages from "../containers/pages";
+import Page from "@frontend/containers/page";
+import Pages from "@frontend/containers/pages";
 
 import { get, set } from "lodash/fp";
 

--- a/src/frontend/pages/components/BlockTest.tsx
+++ b/src/frontend/pages/components/BlockTest.tsx
@@ -1,13 +1,12 @@
 import React from "react";
-
-import Block from "../../../frontend/containers/block/index";
-import AddBlock from "../../../frontend/containers/block/addBlock";
-import { generateTestingDocs1 } from "../../../db/testing_data";
-import * as dbTypes from "../../../db/types";
-import * as cfgTypes from "../../../cfg/types";
-import * as db from "../../../db";
-import * as queries from "../../../db/queries";
-import { LoadedDb } from "../../../db/types";
+import Block from "@frontend/containers/block/index";
+import AddBlock from "@frontend/containers/block/addBlock";
+import { generateTestingDocs1 } from "@db/testing_data";
+import * as dbTypes from "@db/types";
+import * as cfgTypes from "@cfg/types";
+import * as db from "@db/index";
+import * as queries from "@db/queries";
+import { LoadedDb } from "@db/types";
 import { useRxQuery } from "rxdb-hooks";
 
 const docs: dbTypes.DbDocument[] = generateTestingDocs1();

--- a/src/frontend/pages/components/devPanel.tsx
+++ b/src/frontend/pages/components/devPanel.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import { RxCollection, RxDatabase } from "rxdb";
-import { useRxDB } from "rxdb-hooks";
-import * as db from "../../../db";
-import * as dbTypes from "../../../db/types";
+import * as db from "@db/index";
 
 import { addTestingData } from "../../../db/testing_data";
 

--- a/src/frontend/pages/config.tsx
+++ b/src/frontend/pages/config.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import * as cfgTypes from "../../cfg/types";
+import * as cfgTypes from "@cfg/types";
 import { DbsContext } from "./_context";
-import * as cfg from "../../cfg";
-import ConfigEditor from "../containers/configEditor";
+import * as cfg from "@cfg/index";
+import ConfigEditor from "@frontend/containers/configEditor/index";
 
 const ConfigsEditor = () => {
   const dbs = React.useContext(DbsContext);

--- a/src/frontend/pages/db.tsx
+++ b/src/frontend/pages/db.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DbsContext } from "./_context";
-import DBRenderer from "../containers/DBRenderer";
+import DBRenderer from "@frontend/containers/DBRenderer/index";
 
 const DBPage = () => {
   const dbs = React.useContext(DbsContext);

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -13,7 +13,16 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": "../../",
+    "paths": {
+      "@db/*": ["src/db/*"],
+      "@logger/*": ["src/logger/*"],
+      "@store/*": ["src/store/*"],
+      "@cfg/*": ["src/cfg/*"],
+      "@utils/*": ["src/utils/*"],
+      "@frontend/*": ["src/frontend/*"],
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,16 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@db/*": ["src/db/*"],
+      "@logger/*": ["src/logger/*"],
+      "@store/*": ["src/store/*"],
+      "@cfg/*": ["src/cfg/*"],
+      "@utils/*": ["src/utils/*"],
+      "@frontend/*": ["src/frontend/*"],
+    }
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
using paths to prevent confusingly long relative paths for imports and improve consistency (eg when we'd move files around)